### PR TITLE
fix erroeous handing of matrices with padding on the ends of their rows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(SimtTf VERSION 0.2.1 LANGUAGES CXX CUDA)
+project(SimtTf VERSION 0.2.2 LANGUAGES CXX CUDA)
 
 find_package(CUDA REQUIRED)
 find_package(OpenCV 3.4 REQUIRED)


### PR DESCRIPTION
matrices that are presumably not aligned to 16-byte boundaries have padding, so we need to account for it and add a few more parameters to the GPU kernel to correctly bounds check and stride